### PR TITLE
Add publish workflow for Github Actions

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,6 +1,8 @@
 name: Update Github Pages
 on:
   push: { branches: master }
+  workflow_dispatch:
+  pull_request:
 jobs:
   build_and_deploy:
     name: Build & Deploy

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,0 +1,14 @@
+name: Update Github Pages
+on:
+  push: { branches: master }
+jobs:
+  build_and_deploy:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v2
+      - name: Deploy MkDocs
+        uses: mhausenblas/mkdocs-deploy-gh-pages@1.24
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## PR Overview

This PR adds a Github Action so that, when an update occurs on `master`, the `gh-pages` branch gets updated & published to https://help.zooniverse.org/

- Since `help` is built on MKDocs, we're using the [Deploy MKDocs](https://github.com/marketplace/actions/deploy-mkdocs) GH Action.
- This solution is required since, apparently, the Jenkins build is now broken and isn't publishing changes from `master` properly.

### Status

Ready for review.

Wait, do I need to remove `Jenkinsfiles` now that we're using GH Actions?