### PR TITLE
Build with social media cards

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,6 @@
-FROM python:3-alpine
+FROM squidfunk/mkdocs-material
 
 EXPOSE 8000
-WORKDIR /usr/src/help
+WORKDIR /docs
 
-RUN apk --no-cache add git git-fast-import openssh-client
-
-RUN echo "Host *" >> /etc/ssh/ssh_config &&\
-    echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
-
-ADD requirements.txt /usr/src/help
-RUN pip install -r requirements.txt
-
-ADD . /usr/src/help
+ADD . /docs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
     volumes:
-      - ./:/usr/src/help
+      - ./:/docs
     ports:
       - "8000:8000"
-    command: 'mkdocs serve -a 0.0.0.0:8000'
+    command: 'serve -a 0.0.0.0:8000'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Zooniverse Help
+site_url: https://help.zooniverse.org
 repo_url: https://github.com/zooniverse/help/
 theme:
   name: material
@@ -7,3 +8,5 @@ theme:
   palette:
     scheme: default
     primary: teal
+plugins:
+  - social

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
+cairosvg==2.5.2
 mkdocs==1.4.2
 mkdocs-material==8.5.10
+pillow==9.3.0


### PR DESCRIPTION
- Use the custom Docker image for local builds. It has all the dependencies installed for dynamic image building, which are used to build preview image for each page.
- Add new dependencies to the GH Actions build.
- Add the social plugin, which adds OpenGraph social media tags to the `<head>` of each page.